### PR TITLE
Creating the MaximumFileField without a maximum file size does not yield an error at validation time anymore

### DIFF
--- a/multiupload/fields.py
+++ b/multiupload/fields.py
@@ -48,5 +48,5 @@ class MultiFileField(forms.FileField):
         elif self.max_num and num_files > self.max_num:
             raise ValidationError(self.error_messages['max_num'] % {'max_num': self.max_num, 'num_files': num_files})
         for uploaded_file in data:
-            if uploaded_file.size > self.maximum_file_size:
+            if self.maximum_file_size and uploaded_file.size > self.maximum_file_size:
                 raise ValidationError(self.error_messages['file_size'] % {'uploaded_file_name': uploaded_file.name})


### PR DESCRIPTION
If this simple modification is not done, and that `maximum_file_size` , not being passed at initialisation, is `None`, the `validate` function is always raising the `file_size` error.

Thanks for your library by the way, that's exactly what I needed !
