### PR TITLE
Updated `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ $ pip install django-multiupload
 $ pip install -e git+https://github.com/Chive/django-multiupload.git#egg=multiupload
 ```
 
-Usage
------
+## Usage
 
 Add the form field to your form and make sure to save the uploaded files in the form's ``save`` method.
 
@@ -35,11 +34,16 @@ from multiupload.fields import MultiFileField
 class UploadForm(forms.Form):
     attachments = MultiFileField(min_num=1, max_num=3, max_file_size=1024*1024*5)
 
-    # if you need to upload media files, you can use do this:
-	attachments = MultiMediaField(min_num=1, max_num=3, max_file_size=1024*1024*5, media_type = 'video') # 'audio', 'video' or 'image'
+    # If you need to upload media files, you can use do this:
+    attachments = MultiMediaField(
+        min_num=1, 
+        max_num=3, 
+        max_file_size=1024*1024*5, 
+        media_type='video'  # 'audio', 'video' or 'image'
+    )
 
-	# for images (requires Pillow for validation):
-	attachments = MultiImageField(min_num=1, max_num=3, max_file_size=1024*1024*5)
+    # For images (requires Pillow for validation):
+    attachments = MultiImageField(min_num=1, max_num=3, max_file_size=1024*1024*5)
 ```
 
 (The latter two options just add fancy attributes to HTML's `<input>`, restricting the scope to corresponding filetypes)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dead simple drop-in multi file upload field for django forms using HTML5's ``mul
 $ pip install django-multiupload
 ```
 
-* or directly from this repository the get the development version (if you're feeling adventurous)
+* Or directly from this repository the get the development version (if you're feeling adventurous)
 
 ```bash
 $ pip install -e git+https://github.com/Chive/django-multiupload.git#egg=multiupload
@@ -23,7 +23,7 @@ $ pip install -e git+https://github.com/Chive/django-multiupload.git#egg=multiup
 
 Add the form field to your form and make sure to save the uploaded files in the form's ``save`` method.
 
-For more detailed examples visit the [examples section](https://github.com/Chive/django-multiupload/tree/master/examples)
+For more detailed examples visit the [examples section](https://github.com/Chive/django-multiupload/tree/master/examples).
 
 
 ```python
@@ -34,7 +34,7 @@ from multiupload.fields import MultiFileField
 class UploadForm(forms.Form):
     attachments = MultiFileField(min_num=1, max_num=3, max_file_size=1024*1024*5)
 
-    # If you need to upload media files, you can use do this:
+    # If you need to upload media files, you can use this:
     attachments = MultiMediaField(
         min_num=1, 
         max_num=3, 
@@ -46,7 +46,7 @@ class UploadForm(forms.Form):
     attachments = MultiImageField(min_num=1, max_num=3, max_file_size=1024*1024*5)
 ```
 
-(The latter two options just add fancy attributes to HTML's `<input>`, restricting the scope to corresponding filetypes)
+The latter two options just add fancy attributes to HTML's `<input>`, restricting the scope to corresponding filetypes.
 
 ```python
 # models.py


### PR DESCRIPTION
Fixed `Usage` heading, since it was defined with `---`, while every other headings are defined with `#`.

Fixed detailed example to be:
1. Fully visible without horizontal scrolling
2. PEP-8 friendly (capital letters in the line-comments, only spaces for indent)