### PR TITLE
Added support for Django 2.1

### DIFF
--- a/multiupload/fields.py
+++ b/multiupload/fields.py
@@ -20,11 +20,11 @@ class MultiUploadMetaInput(forms.ClearableFileInput):
         self.multiple = kwargs.pop('multiple', True)
         super(MultiUploadMetaInput, self).__init__(*args, **kwargs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if self.multiple:
             attrs['multiple'] = 'multiple'
 
-        return super(MultiUploadMetaInput, self).render(name, value, attrs)
+        return super(MultiUploadMetaInput, self).render(name, value, attrs, renderer)
 
     def value_from_datadict(self, data, files, name):
         if hasattr(files, 'getlist'):


### PR DESCRIPTION
As of Django 2.1,

Support for Widget.render() methods without the renderer argument is removed.
https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1

This change should resolve that issue.